### PR TITLE
Extend functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+existing_plans_and_devices.yaml

--- a/srx_gui/plots.py
+++ b/srx_gui/plots.py
@@ -294,6 +294,7 @@ class AutoSRXPlot(AutoPlotter):
 
         self._plot_number = 0
         self._plot_number_displayed_max = 3
+        self._figure_key_plot_numbers = {}
 
     @property
     def monitored_field(self):
@@ -334,6 +335,7 @@ class AutoSRXPlot(AutoPlotter):
         nx, ny = run._document_cache.start_doc["scan"]["shape"]
         xstart, xstop = run._document_cache.start_doc["scan"]["scan_input"][0:2]
         ystart, ystop = run._document_cache.start_doc["scan"]["scan_input"][2:4]
+        scan_id = run._document_cache.start_doc["scan_id"]
         plot_type = "line" if ny == 1 else "image"
         plan_name = run.metadata["start"].get("plan_name").split(" ")
 
@@ -344,10 +346,22 @@ class AutoSRXPlot(AutoPlotter):
             title = " ".join(plan_name)
             subtitle = y_axis
             if plot_type == "image":
-                key = f"plot2d-{self._plot_number % self._plot_number_displayed_max}"
+                key, pn = "", self._plot_number
+                for n in range(self._plot_number_displayed_max):
+                    key_tmp = f"plot2d-{n}"
+                    if key_tmp not in self._models:
+                        key = key_tmp
+                        break
+                    else:
+                        if self._figure_key_plot_numbers[key_tmp] < pn:
+                            pn = self._figure_key_plot_numbers[key_tmp]
+                            key = key_tmp
+                key_plot_number = self._plot_number
                 self._plot_number += 1
             else:
-                key = f"{title}: {subtitle} {plot_type}"
+                key = "plot1d"
+                key_plot_number = 0
+                # key = f"{title}: {subtitle} {plot_type}"  # Original title
 
             append_figure = False
             if key in self._models:
@@ -376,6 +390,13 @@ class AutoSRXPlot(AutoPlotter):
                 self._models[key] = [model]
                 self._figure_dict[key] = figure
                 append_figure = True
+
+        self._figure_key_plot_numbers[key] = key_plot_number
+
+        if plot_type == "image":
+            figure.short_title = f"2D: {scan_id}"
+        elif plot_type == "line":
+            figure.short_title = f"1D: {scan_id}"
 
         for model in models:
             model.add_run(run)

--- a/srx_gui/plots.py
+++ b/srx_gui/plots.py
@@ -292,6 +292,9 @@ class AutoSRXPlot(AutoPlotter):
 
         self.plot_builders.events.removed.connect(self._on_plot_builder_removed)
 
+        self._plot_number = 0
+        self._plot_number_displayed_max = 3
+
     @property
     def monitored_field(self):
         return self._monitored_field
@@ -340,7 +343,11 @@ class AutoSRXPlot(AutoPlotter):
         for y_axis in y_axes:
             title = " ".join(plan_name)
             subtitle = y_axis
-            key = f"{title}: {subtitle} {plot_type}"
+            if plot_type == "image":
+                key = f"plot2d-{self._plot_number % self._plot_number_displayed_max}"
+                self._plot_number += 1
+            else:
+                key = f"{title}: {subtitle} {plot_type}"
 
             append_figure = False
             if key in self._models:

--- a/srx_gui/tests/startup/user_group_permissions.yaml
+++ b/srx_gui/tests/startup/user_group_permissions.yaml
@@ -1,0 +1,46 @@
+user_groups:
+  root:  # The group includes all available plan and devices
+    allowed_plans:
+      - null  # Allow all
+    forbidden_plans:
+      - ":^_"  # All plans with names starting with '_'
+    allowed_devices:
+      - null  # Allow all
+    forbidden_devices:
+      - ":^_:?.*"  # All devices with names starting with '_'
+    allowed_functions:
+      - null  # Allow all
+    forbidden_functions:
+      - ":^_"  # All functions with names starting with '_'
+  admin:  # The group includes beamline staff, includes all or most of the plans and devices
+    allowed_plans:
+      - ":.*"  # Different way to allow all plans.
+    forbidden_plans:
+      - null  # Nothing is forbidden
+    allowed_devices:
+      - ":?.*:depth=5"  # Allow all device and subdevices. Maximum deepth for subdevices is 5.
+    forbidden_devices:
+      - null  # Nothing is forbidden
+    allowed_functions:
+      - "function_sleep"  # Explicitly listed name
+  test_user:  # Users with limited access capabilities
+    allowed_plans:
+      - ":^count"  # Use regular expression patterns
+      - ":scan$"
+    forbidden_plans:
+      - ":^adaptive_scan$" # Use regular expression patterns
+      - ":^inner_product"
+    allowed_devices:
+      - ":^det:?.*"  # Use regular expression patterns
+      - ":^motor:?.*"
+      - ":^sim_bundle_A:?.*"
+    forbidden_devices:
+      - ":^det[3-5]$:?.*" # Use regular expression patterns
+      - ":^motor\\d+$:?.*"
+    allowed_functions:
+      - ":element$"
+      - ":elements$"
+      - "function_sleep"
+      - "clear_buffer"
+    forbidden_functions:
+      - ":^_"  # All functions with names starting with '_'

--- a/srx_gui/viewer.py
+++ b/srx_gui/viewer.py
@@ -1,6 +1,7 @@
 import os
 import copy
 import pprint
+import uuid
 
 from bluesky_widgets.models.run_engine_client import RunEngineClient
 from bluesky_widgets.qt import Window
@@ -76,7 +77,7 @@ class Viewer(ViewerModel):
                 self.dispatcher = RemoteDispatcher(
                     topics=topics,
                     bootstrap_servers=bootstrap_servers,
-                    group_id="widgets_test",
+                    group_id="widgets_test_" + str(uuid.uuid4()).split("-")[-1],  # Random group name
                     consumer_config=consumer_config,
                 )
 


### PR DESCRIPTION
- Unique Kafka group ID names: allows to run multiple copies of the application to monitor the same stream.
- Display up to 3 2D maps simultaneously. The number of displayed 2D maps may be parametrized later.